### PR TITLE
Fix pillow

### DIFF
--- a/kivy_ios/recipes/itsdangerous/__init__.py
+++ b/kivy_ios/recipes/itsdangerous/__init__.py
@@ -6,19 +6,19 @@ import sh
 
 
 class ItsDangerousRecipe(PythonRecipe):
-    version = "1.1.0"
+    version = "2.2.0"
     url = "https://github.com/mitsuhiko/itsdangerous/archive/{version}.zip"
     depends = ["python"]
 
     def install(self):
         plat = list(self.platforms_to_build)[0]
         build_dir = self.get_build_dir(plat)
-        hostpython = sh.Command(self.ctx.hostpython)
+        hostpython_pip = sh.Command(join(self.ctx.dist_dir, "hostpython3", "bin", "pip3"))
         build_env = plat.get_env()
         dest_dir = join(self.ctx.dist_dir, "root", "python3")
         build_env['PYTHONPATH'] = self.ctx.site_packages_dir
         with cd(build_dir):
-            shprint(hostpython, "setup.py", "install", "--prefix", dest_dir, _env=build_env)
+            shprint(hostpython_pip, "install", build_dir, "--prefix", dest_dir, _env=build_env)
 
 
 recipe = ItsDangerousRecipe()

--- a/kivy_ios/recipes/pillow/__init__.py
+++ b/kivy_ios/recipes/pillow/__init__.py
@@ -5,8 +5,9 @@ import os
 
 
 class PillowRecipe(CythonRecipe):
-    version = "8.2.0"
-    url = "https://pypi.python.org/packages/source/P/Pillow/Pillow-{version}.tar.gz"
+    version = "11.0.0"
+    #url = "https://pypi.python.org/packages/source/p/pillow/pillow-{version}.tar.gz"
+    url = "https://github.com/python-pillow/Pillow/archive/refs/tags/{version}.tar.gz"
     library = "libpillow.a"
     depends = [
         "hostpython3",

--- a/kivy_ios/recipes/pillow/bypass-find-library.patch
+++ b/kivy_ios/recipes/pillow/bypass-find-library.patch
@@ -1,10 +1,9 @@
-diff -Naur Pillow-8.2.0.orig/setup.py Pillow-8.2.0/setup.py
---- Pillow-8.2.0.orig/setup.py	2021-04-05 11:11:26.000000000 +0200
-+++ Pillow-8.2.0/setup.py	2021-04-05 11:16:12.000000000 +0200
-@@ -222,12 +222,9 @@
+--- Pillow-11.0.0.orig/setup.py	2024-10-15 01:55:00.000000000 -0400
++++ Pillow-11.0.0/setup.py	2024-11-19 12:20:09.514795844 -0500
+@@ -231,12 +231,9 @@
  
  
- def _find_library_file(self, library):
+ def _find_library_file(self: pil_build_ext, library: str) -> str | None:
 -    ret = self.compiler.find_library_file(self.compiler.library_dirs, library)
 -    if ret:
 -        _dbg("Found library %s at %s", (library, ret))
@@ -16,4 +15,4 @@ diff -Naur Pillow-8.2.0.orig/setup.py Pillow-8.2.0/setup.py
 +    return True
  
  
- def _find_include_dir(self, dirname, include):
+ def _find_include_dir(self: pil_build_ext, dirname: str, include: str) -> bool | str:


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the itsdangerous and Pillow recipes to their latest versions and update the installation methods to ensure compatibility with the new releases.

Bug Fixes:
- Update the Pillow recipe to use the correct URL for version 11.0.0, ensuring compatibility with the latest release.

Enhancements:
- Upgrade the itsdangerous recipe to version 2.2.0 and modify the installation process to use pip3 instead of setup.py.